### PR TITLE
Add keywords and remove dublicates

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,8 @@
     "lint": "eslint *.js",
     "test": "jest"
   },
-  "keywords": [],
+  "keywords": ["pre-commit", "git", "hook", "lint"],
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/toplenboren/simple-pre-commit/issues"
-  },
   "homepage": "https://github.com/toplenboren/simple-pre-commit",
   "lint-staged": {
     "*.js": "eslint"


### PR DESCRIPTION
`bugs` with `${homepage}/issue` is a default value of `bugs`. You can remove it and npm website will show the same URL.

And I added `keywords` for npm search optimization.