### PR TITLE
Fix simple pre commit without dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ Note that you should manually run `npx simple-pre-commit` **every time you chang
 
 ### Additional configuration options
 
-You can also add the `.simple-pre-commit.json` to the project and write the command inside it, if you do not want to put command inside `package.json`
+You can also add the `.simple-pre-commit.json` or `simple-pre-commit.json` to the project and write the command inside it, if you do not want to put command inside `package.json`
 
-That way, `.simple-pre-commit.json` should look like this and `package.json` may not have `simple-pre-commit` configuration inside it
+That way, `.simple-pre-commit.json` or `simple-pre-commit.json` should look like this and `package.json` may not have `simple-pre-commit` configuration inside it
 
 ```json
 { 

--- a/_tests/project_with_configuration_in_separate_json_2/.simple-pre-commit.json
+++ b/_tests/project_with_configuration_in_separate_json_2/.simple-pre-commit.json
@@ -1,0 +1,3 @@
+{
+  "simple-pre-commit": "test"
+}

--- a/_tests/project_with_configuration_in_separate_json_2/package.json
+++ b/_tests/project_with_configuration_in_separate_json_2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "simple-pre-commit-test-package",
+  "version": "1.0.0",
+  "devDependencies": {
+    "simple-pre-commit": "1.0.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-pre-commit",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A simple, zero dependency tool for setting up git pre-commit hook for small projects",
   "author": "Mikhail Gorbunov <toplenboren@gmail.com> (toplenboren.gituhb.io)",
   "main": "./simple-pre-commit.js",

--- a/simple-pre-commit.js
+++ b/simple-pre-commit.js
@@ -101,12 +101,13 @@ function getCommandFromConfig(projectRootPath) {
 
     // every function here should accept projectRootPath as first argument and return either string or undefined
     const sources = [
-        _getCommandFromSimplePreCommitJson,
-        _getCommandFromPackageJson,
+        () => _getCommandFromFile(projectRootPath, '.simple-pre-commit.json'),
+        () => _getCommandFromFile(projectRootPath, 'simple-pre-commit.json'),
+        () => _getCommandFromPackageJson(projectRootPath),
     ]
 
     for (let i = 0; i < sources.length; ++i) {
-        let command = sources[i](projectRootPath)
+        let command = sources[i]()
         if (command) {
             return command
         }
@@ -164,18 +165,23 @@ function _getCommandFromPackageJson(projectRootPath = process.cwd()) {
 }
 
 /**
- * Gets user-set command from simple-pre-commit.json
+ * Gets user-set command from file
  * Since the file is not required in node.js projects it returns undefined if something is off
  * @param {string} projectRootPath
+ * @param {string} fileName
  * @return {string | undefined}
  */
-function _getCommandFromSimplePreCommitJson(projectRootPath) {
+function _getCommandFromFile(projectRootPath, fileName) {
     if (typeof projectRootPath !== "string") {
         throw TypeError("projectRootPath is not a string")
     }
 
+    if (typeof fileName !== "string") {
+        throw TypeError("fileName is not a string")
+    }
+
     try {
-        const simplePreCommitJsonPath = path.normalize(projectRootPath + '/simple-pre-commit.json')
+        const simplePreCommitJsonPath = path.normalize(projectRootPath + '/' + fileName)
         const simplePreCommitJsonRaw = fs.readFileSync(simplePreCommitJsonPath)
         const simplePreCommitJson = JSON.parse(simplePreCommitJsonRaw)
         return simplePreCommitJson['simple-pre-commit']

--- a/simple-pre-commit.test.js
+++ b/simple-pre-commit.test.js
@@ -59,6 +59,7 @@ test('returns false if simple pre commit isn`t in deps', () => {
 
 const commandInPackageJsonProjectPath = path.normalize(path.join(process.cwd(), '_tests', 'project_with_configuration_in_package_json'))
 const commandInSeparateJsonProjectPath = path.normalize(path.join(process.cwd(), '_tests', 'project_with_configuration_in_separate_json'))
+const commandInSeparateJsonProjectPath2 = path.normalize(path.join(process.cwd(), '_tests', 'project_with_configuration_in_separate_json_2'))
 const notConfiguredProjectPath = path.normalize(path.join(process.cwd(), '_tests', 'project_without_configuration'))
 
 test('returns command if configured from package.json', () => {
@@ -69,7 +70,10 @@ test('returns command if configured from simple-pre-commit.json', () => {
     expect(spc.getCommandFromConfig(commandInSeparateJsonProjectPath)).toBe("test")
 })
 
+test('returns command if configured from .simple-pre-commit.json', () => {
+    expect(spc.getCommandFromConfig(commandInSeparateJsonProjectPath2)).toBe("test")
+})
+
 test('returns undefined if were not able to parse command', () => {
     expect(spc.getCommandFromConfig(notConfiguredProjectPath)).toBe(undefined)
 })
-


### PR DESCRIPTION
Fixes #15 

- Adds an ability to set either `simple-pre-commit.json` or `.simple-pre-commit.json` as configuration. 